### PR TITLE
Use cached download to reduce google drive load

### DIFF
--- a/PULSE.py
+++ b/PULSE.py
@@ -19,9 +19,14 @@ class PULSE(torch.nn.Module):
 
         cache_dir = Path(cache_dir)
         cache_dir.mkdir(parents=True, exist_ok = True)
-        if self.verbose: print("Loading Synthesis Network")
-        with open_url("https://drive.google.com/uc?id=1TCViX1YpQyRsklTVYEJwdbmK91vklCo8", cache_dir=cache_dir, verbose=verbose) as f:
-            self.synthesis.load_state_dict(torch.load(f))
+        if self.verbose:
+            print("Loading Synthesis Network")
+        synthesis_cached = f"{cache_dir}/synthesis.pt"
+        if Path(synthesis_cached).exists():
+            self.synthesis.load_state_dict(torch.load(synthesis_cached))
+        else:
+            with open_url("https://drive.google.com/uc?id=1TCViX1YpQyRsklTVYEJwdbmK91vklCo8", cache_dir=cache_dir, verbose=verbose) as f:
+                self.synthesis.load_state_dict(torch.load(f))
 
         for param in self.synthesis.parameters():
             param.requires_grad = False
@@ -31,10 +36,15 @@ class PULSE(torch.nn.Module):
         if Path("gaussian_fit.pt").exists():
             self.gaussian_fit = torch.load("gaussian_fit.pt")
         else:
-            if self.verbose: print("\tLoading Mapping Network")
+            if self.verbose:
+                print("\tLoading Mapping Network")
             mapping = G_mapping().cuda()
 
-            with open_url("https://drive.google.com/uc?id=14R6iHGf5iuVx3DMNsACAl7eBr7Vdpd0k", cache_dir=cache_dir, verbose=verbose) as f:
+            mapping_cached = f"{cache_dir}/mapping.pt"
+            if Path(mapping_cached).exists():
+                mapping.load_state_dict(torch.load(mapping_cached))
+            else:
+                with open_url("https://drive.google.com/uc?id=14R6iHGf5iuVx3DMNsACAl7eBr7Vdpd0k", cache_dir=cache_dir, verbose=verbose) as f:
                     mapping.load_state_dict(torch.load(f))
 
             if self.verbose: print("\tRunning Mapping Network")

--- a/align_face.py
+++ b/align_face.py
@@ -30,9 +30,15 @@ cache_dir.mkdir(parents=True, exist_ok=True)
 output_dir = Path(args.output_dir)
 output_dir.mkdir(parents=True,exist_ok=True)
 
-print("Downloading Shape Predictor")
-f=open_url("https://drive.google.com/uc?id=1huhv8PYpNNKbGCLOaYUjOgR1pY5pmbJx", cache_dir=cache_dir, return_path=True)
-predictor = dlib.shape_predictor(f)
+predictor_cached = f"{cache_dir}/shape_predictor_68_face_landmarks.dat"
+
+if Path(predictor_cached).exists():
+    print("Using cached Shape Predictor")
+    predictor = dlib.shape_predictor(predictor_cached)
+else:
+    print("Downloading Shape Predictor")
+    with open_url("https://drive.google.com/uc?id=1huhv8PYpNNKbGCLOaYUjOgR1pY5pmbJx", cache_dir=cache_dir, return_path=True) as f:
+        predictor = dlib.shape_predictor(f)
 
 for im in Path(args.input_dir).glob("*.*"):
     faces = align_face(str(im),predictor)


### PR DESCRIPTION
`run.py` and `PULSE.py` attempt to download files from Google drive every time they are executed. This leads to `OSError: Google Drive quota exceeded` quite fast. Checking the cache directory first for `synthesis.pt`, `mapping.pt` or `shape_predictor_68_face_landmarks.dat` reduces server queries and also reduces initialization time.

Little remark: While automatic downloading approaches failed every time, I was able to copy the URL into my browser and download all the files manually as a workaround.